### PR TITLE
Fix twitter/keybase handle validation based on updated spec

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"net/mail"
 	"net/url"
+	"regexp"
 
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
@@ -44,6 +45,13 @@ const (
 	MinSupportedVersion = 1
 	// MaxSupportedVersion is the maximum supported entity metadata version.
 	MaxSupportedVersion = 1
+)
+
+var (
+	// TwitterHandleRegexp is the regular expression used for validating the Twitter field.
+	TwitterHandleRegexp = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+	// KeybaseHandleRegexp is the regular expression used for validating the Keybase field.
+	KeybaseHandleRegexp = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
 )
 
 // Provider is the read-only registry provider interface.
@@ -141,10 +149,20 @@ func (e *EntityMetadata) ValidateBasic() error {
 	if len(e.Keybase) > MaxEntityKeybaseLength {
 		return fmt.Errorf("entity keybase handle too long (length: %d max: %d)", len(e.Keybase), MaxEntityKeybaseLength)
 	}
+	if len(e.Keybase) > 0 {
+		if !KeybaseHandleRegexp.MatchString(e.Keybase) {
+			return fmt.Errorf("entity keybase handle is malformed")
+		}
+	}
 
 	// Twitter.
 	if len(e.Twitter) > MaxEntityTwitterLength {
 		return fmt.Errorf("entity twitter handle too long (length: %d max: %d)", len(e.Twitter), MaxEntityTwitterLength)
+	}
+	if len(e.Twitter) > 0 {
+		if !TwitterHandleRegexp.MatchString(e.Twitter) {
+			return fmt.Errorf("entity twitter handle is malformed")
+		}
 	}
 
 	return nil

--- a/registry_test.go
+++ b/registry_test.go
@@ -33,10 +33,18 @@ func TestEntityMetadata(t *testing.T) {
 		{"BadEmail2", EntityMetadata{Versioned: cbor.NewVersioned(1), Email: "Hello World <hello@world.org>"}, false},
 		{"BadEmail3", EntityMetadata{Versioned: cbor.NewVersioned(1), Email: "@world.org"}, false},
 		{"BadEmail4", EntityMetadata{Versioned: cbor.NewVersioned(1), Email: "hello@.org"}, false},
-		{"ValidKeybase", EntityMetadata{Versioned: cbor.NewVersioned(1), Keybase: "helloworld"}, true},
+		{"ValidKeybase", EntityMetadata{Versioned: cbor.NewVersioned(1), Keybase: "Hello_world42"}, true},
 		{"TooLongKeybase", EntityMetadata{Versioned: cbor.NewVersioned(1), Keybase: "tootootootootootootootootootoolong"}, false},
-		{"ValidTwitter", EntityMetadata{Versioned: cbor.NewVersioned(1), Twitter: "helloworld"}, true},
+		{"BadKeybase1", EntityMetadata{Versioned: cbor.NewVersioned(1), Keybase: "helloworld-"}, false},
+		{"BadKeybase2", EntityMetadata{Versioned: cbor.NewVersioned(1), Keybase: "https://keybase.io/hello"}, false},
+		{"BadKeybase3", EntityMetadata{Versioned: cbor.NewVersioned(1), Keybase: "foo-bar"}, false},
+		{"BadKeybase4", EntityMetadata{Versioned: cbor.NewVersioned(1), Keybase: "foo:bar"}, false},
+		{"ValidTwitter", EntityMetadata{Versioned: cbor.NewVersioned(1), Twitter: "Hello_world42"}, true},
 		{"TooLongTwitter", EntityMetadata{Versioned: cbor.NewVersioned(1), Twitter: "tootootootootootootootootootoolong"}, false},
+		{"BadTwitter1", EntityMetadata{Versioned: cbor.NewVersioned(1), Twitter: "helloworld-"}, false},
+		{"BadTwitter2", EntityMetadata{Versioned: cbor.NewVersioned(1), Twitter: "https://twitter.com/hello"}, false},
+		{"BadTwitter3", EntityMetadata{Versioned: cbor.NewVersioned(1), Twitter: "foo-bar"}, false},
+		{"BadTwitter4", EntityMetadata{Versioned: cbor.NewVersioned(1), Twitter: "foo:bar"}, false},
 	} {
 		err := tc.meta.ValidateBasic()
 		switch tc.valid {


### PR DESCRIPTION
Implementation of https://github.com/oasisprotocol/metadata-registry/pull/18, also see https://github.com/oasisprotocol/metadata-registry/issues/14.