### PR TITLE
Add markdownlint and golangci-lint configurations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,76 @@
+# golangci-lint configuration.
+
+# For more information, see:
+# https://golangci-lint.run/usage/configuration/.
+
+linters:
+  # Disable all linters except the ones explicitly listed below.
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exhaustive
+    - exportloopref
+    - funlen
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - godox
+    - gofumpt
+    - goheader
+    - goimports
+    - golint
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - maligned
+    - misspell
+    - nakedret
+    - nestif
+    - noctx
+    - nolintlint
+    - prealloc
+    - rowserrcheck
+    - scopelint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - sqlclosecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+    # Don't enable:
+    # - gochecknoglobals
+    # - goerr113
+    # - gofmt
+    # - gomnd
+    # - testpackage
+    # - wsl
+
+linters-settings:
+  exhaustive:
+    # Switch statements are to be considered exhaustive if a 'default' case is
+    # present, even if all enum members aren't listed in the switch.
+    default-signifies-exhaustive: true
+  govet:
+    # Enabled checking for shadowed variables.
+    check-shadowing: true
+  maligned:
+    # Print the suggested struct structure with a more effective memory layout.
+    suggest-new: true

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,18 @@
+# markdownlint configuration.
+
+# For more information, see:
+# https://github.com/DavidAnson/markdownlint#optionsconfig.
+
+# Enable all rules.
+default: true
+
+line-length:
+  # Line length checking is not strict by default.
+  strict: true
+  line_length: 80
+  # Allow longer lines for code blocks.
+  code_block_line_length: 100
+
+# Do not always require language specifiers with fenced code blocks since they
+# are not part of the Markdown spec.
+fenced-code-language: false

--- a/README.md
+++ b/README.md
@@ -87,9 +87,11 @@ It will store the signed entity metadata statement to the
 public key, e.g.
 `918cfe60b903e9d2c3003eaa78997f4fd95d66597f20cea8693e447b6637604c.json`.
 
+<!-- markdownlint-disable line-length -->
 [oasis-cli-flags]:
   https://docs.oasis.dev/general/manage-tokens/oasis-cli-tools/setup#signer-flags
 [Oasis app 1.9.0+ releases]: https://github.com/Zondax/ledger-oasis/releases
+<!-- markdownlint-enable line-length -->
 
 ### Contributing Entity Metadata Statement to Production Oasis Metadata Registry
 

--- a/fs.go
+++ b/fs.go
@@ -105,7 +105,10 @@ func (p *fsProvider) GetEntities(ctx context.Context) (map[signature.PublicKey]*
 		}
 
 		if fi.Size() > MaxStatementSize {
-			return nil, fmt.Errorf("%w: entity: statement too big (size: %d max: %d): %s", ErrCorruptedRegistry, fi.Size(), MaxStatementSize, fi.Name())
+			return nil, fmt.Errorf(
+				"%w: entity: statement too big (size: %d max: %d): %s",
+				ErrCorruptedRegistry, fi.Size(), MaxStatementSize, fi.Name(),
+			)
 		}
 
 		var result *EntityMetadata

--- a/gen_vectors/main.go
+++ b/gen_vectors/main.go
@@ -18,7 +18,11 @@ func main() {
 	chainContext.FromBytes([]byte("metadata registry test vectors"))
 	signature.SetChainContext(chainContext.String())
 
-	var vectors []testvectors.EntityMetadataTestVector
+	vectors := make(
+		[]testvectors.EntityMetadataTestVector,
+		0,
+		len(testcases.EntityMetadataBasicVersionAndSize)+len(testcases.EntityMetadataExtendedVersionAndSize),
+	)
 
 	for _, tc := range testcases.EntityMetadataBasicVersionAndSize {
 		vec := testvectors.MakeEntityMetadataTestVector(

--- a/oasis-registry/cmd/entity.go
+++ b/oasis-registry/cmd/entity.go
@@ -43,6 +43,27 @@ var (
 	entityLogger = logging.GetLogger("cmd/entity")
 )
 
+func logErrorAndExit(msg string, err error) {
+	entityLogger.Error(msg, "err", err)
+	os.Exit(1)
+}
+
+func loadSigner() (signature.Signer, error) {
+	signerDir, err := cmdSigner.CLIDirOrPwd()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve signer dir: %w", err)
+	}
+	signerFactory, err := cmdSigner.NewFactory(cmdSigner.Backend(), signerDir, signature.SignerEntity)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create signer factory: %w", err)
+	}
+	signer, err := signerFactory.Load(signature.SignerEntity)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load signer: %w", err)
+	}
+	return signer, nil
+}
+
 func doEntityUpdate(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		entityLogger.Error("expected a single argument")
@@ -54,50 +75,24 @@ func doEntityUpdate(cmd *cobra.Command, args []string) {
 	// Open and parse the passed entity metadata file.
 	rawEntity, err := ioutil.ReadFile(args[0])
 	if err != nil {
-		entityLogger.Error("failed to read entity descriptor",
-			"err", err,
-		)
-		os.Exit(1)
+		logErrorAndExit("failed to read entity descriptor", err)
 	}
 
 	var entity registry.EntityMetadata
 	if err = json.Unmarshal(rawEntity, &entity); err != nil {
-		entityLogger.Error("failed to parse serialized entity metadata",
-			"err", err,
-		)
-		os.Exit(1)
+		logErrorAndExit("failed to parse serialized entity metadata", err)
 	}
 
 	if !viper.GetBool(cfgSkipValidation) {
 		if err = entity.ValidateBasic(); err != nil {
-			entityLogger.Error("provided entity metadata is invalid",
-				"err", err,
-			)
-			os.Exit(1)
+			logErrorAndExit("provided entity metadata is invalid", err)
 		}
 	}
 
 	// Get the signer.
-	signerDir, err := cmdSigner.CLIDirOrPwd()
+	signer, err := loadSigner()
 	if err != nil {
-		entityLogger.Error("failed to retrieve signer dir",
-			"err", err,
-		)
-		os.Exit(1)
-	}
-	signerFactory, err := cmdSigner.NewFactory(cmdSigner.Backend(), signerDir, signature.SignerEntity)
-	if err != nil {
-		entityLogger.Error("failed to create signer factory",
-			"err", err,
-		)
-		os.Exit(1)
-	}
-	signer, err := signerFactory.Load(signature.SignerEntity)
-	if err != nil {
-		entityLogger.Error("failed to load signer",
-			"err", err,
-		)
-		os.Exit(1)
+		logErrorAndExit("failed to load signer", err)
 	}
 
 	// Show descriptor and ask for confirmation.
@@ -120,17 +115,11 @@ func doEntityUpdate(cmd *cobra.Command, args []string) {
 	// Sign the descriptor.
 	signed, err := registry.SignEntityMetadata(signer, &entity)
 	if err != nil {
-		entityLogger.Error("failed to sign metadata",
-			"err", err,
-		)
-		os.Exit(1)
+		logErrorAndExit("failed to sign metadata", err)
 	}
 
 	if err = p.UpdateEntity(signed); err != nil {
-		entityLogger.Error("failed to update metadata",
-			"err", err,
-		)
-		os.Exit(1)
+		logErrorAndExit("failed to update metadata", err)
 	}
 
 	fmt.Printf("Updated entity %s\n", signer.Public())

--- a/oasis-registry/cmd/entity.go
+++ b/oasis-registry/cmd/entity.go
@@ -125,7 +125,7 @@ func doEntityUpdate(cmd *cobra.Command, args []string) {
 	fmt.Printf("Updated entity %s\n", signer.Public())
 }
 
-func init() {
+func init() { //nolint:gochecknoinits
 	entityFlags.Bool(cfgSkipValidation, false, "skip metadata validation")
 	entityFlags.AddFlagSet(cmdSigner.Flags)
 	entityFlags.AddFlagSet(cmdSigner.CLIFlags)

--- a/oasis-registry/cmd/registry.go
+++ b/oasis-registry/cmd/registry.go
@@ -100,7 +100,7 @@ func doVerify(cmd *cobra.Command, args []string) {
 	}
 }
 
-func init() {
+func init() { //nolint:gochecknoinits
 	verifyFlags.String(cfgUpdate, "", "verify update from a previous registry snapshot")
 
 	_ = viper.BindPFlags(verifyFlags)

--- a/registry.go
+++ b/registry.go
@@ -234,7 +234,7 @@ type SignedEntityMetadata struct {
 }
 
 // Open first verifies the blob signature and then unmarshals the blob.
-func (s *SignedEntityMetadata) Open(meta *EntityMetadata) error { // nolint: interfacer
+func (s *SignedEntityMetadata) Open(meta *EntityMetadata) error {
 	return s.Signed.Open(EntityMetadataSignatureContext, meta)
 }
 

--- a/testcases/testcases.go
+++ b/testcases/testcases.go
@@ -30,21 +30,25 @@ type EntityMetadataTestCase struct {
 }
 
 var (
+	v0 = cbor.NewVersioned(0)
+	v1 = cbor.NewVersioned(1)
+	v2 = cbor.NewVersioned(2)
+
 	// EntityMetadataBasicVersionAndSize are the entity metadata test cases that
 	// contain test cases for basic version and field sizes checks.
 	EntityMetadataBasicVersionAndSize []EntityMetadataTestCase = []EntityMetadataTestCase{
-		{"InvalidVersion1", registry.EntityMetadata{Versioned: cbor.NewVersioned(0)}, false},
-		{"InvalidVersion2", registry.EntityMetadata{Versioned: cbor.NewVersioned(2)}, false},
-		{"ValidName", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Name: EntityValidName}, true},
-		{"TooLongName", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Name: EntityTooLongName}, false},
-		{"ValidURL", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), URL: EntityValidURL}, true},
-		{"TooLongURL", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), URL: EntityTooLongURL}, false},
-		{"ValidEmail", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Email: EntityValidEmail}, true},
-		{"TooLongEmail", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Email: EntityTooLongEmail}, false},
-		{"ValidKeybase", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Keybase: EntityValidKeybase}, true},
-		{"TooLongKeybase", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Keybase: EntityTooLongKeybase}, false},
-		{"ValidTwitter", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Twitter: EntityValidTwitter}, true},
-		{"TooLongTwitter", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Twitter: EntityTooLongTwitter}, false},
+		{"InvalidVersion1", registry.EntityMetadata{Versioned: v0}, false},
+		{"InvalidVersion2", registry.EntityMetadata{Versioned: v2}, false},
+		{"ValidName", registry.EntityMetadata{Versioned: v1, Name: EntityValidName}, true},
+		{"TooLongName", registry.EntityMetadata{Versioned: v1, Name: EntityTooLongName}, false},
+		{"ValidURL", registry.EntityMetadata{Versioned: v1, URL: EntityValidURL}, true},
+		{"TooLongURL", registry.EntityMetadata{Versioned: v1, URL: EntityTooLongURL}, false},
+		{"ValidEmail", registry.EntityMetadata{Versioned: v1, Email: EntityValidEmail}, true},
+		{"TooLongEmail", registry.EntityMetadata{Versioned: v1, Email: EntityTooLongEmail}, false},
+		{"ValidKeybase", registry.EntityMetadata{Versioned: v1, Keybase: EntityValidKeybase}, true},
+		{"TooLongKeybase", registry.EntityMetadata{Versioned: v1, Keybase: EntityTooLongKeybase}, false},
+		{"ValidTwitter", registry.EntityMetadata{Versioned: v1, Twitter: EntityValidTwitter}, true},
+		{"TooLongTwitter", registry.EntityMetadata{Versioned: v1, Twitter: EntityTooLongTwitter}, false},
 	}
 
 	// EntityMetadataExtendedVersionAndSize are the entity metadata test cases
@@ -56,28 +60,28 @@ var (
 	// EntityMetadataFieldSemantics are the entity metadata test cases that
 	// contain test cases for checking fields' semantics.
 	EntityMetadataFieldSemantics []EntityMetadataTestCase = []EntityMetadataTestCase{
-		{"ValidURL", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), URL: EntityValidURL}, true},
-		{"BadSchemeURL", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), URL: "http://hello.world/bar/goo"}, false},
-		{"BadQueryURL", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), URL: "https://hello.world/bar?goo=1"}, false},
-		{"BadFragmentURL", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), URL: "https://hello.world/bar#goo"}, false},
-		{"BadPortURL", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), URL: "https://hello.world:123/bar"}, false},
-		{"BadURL1", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), URL: "hello.world"}, false},
-		{"BadURL2", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), URL: "127.0.0.1:1234"}, false},
-		{"ValidEmail", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Email: EntityValidEmail}, true},
-		{"BadEmail1", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Email: "hello world.org"}, false},
-		{"BadEmail2", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Email: "Hello World <hello@world.org>"}, false},
-		{"BadEmail3", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Email: "@world.org"}, false},
-		{"BadEmail4", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Email: "hello@.org"}, false},
-		{"ValidKeybase", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Keybase: EntityValidKeybase}, true},
-		{"BadKeybase1", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Keybase: "helloworld-"}, false},
-		{"BadKeybase2", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Keybase: "https://keybase.io/hello"}, false},
-		{"BadKeybase3", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Keybase: "foo-bar"}, false},
-		{"BadKeybase4", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Keybase: "foo:bar"}, false},
-		{"ValidTwitter", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Twitter: EntityValidTwitter}, true},
-		{"BadTwitter1", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Twitter: "helloworld-"}, false},
-		{"BadTwitter2", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Twitter: "https://twitter.com/hello"}, false},
-		{"BadTwitter3", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Twitter: "foo-bar"}, false},
-		{"BadTwitter4", registry.EntityMetadata{Versioned: cbor.NewVersioned(1), Twitter: "foo:bar"}, false},
+		{"ValidURL", registry.EntityMetadata{Versioned: v1, URL: EntityValidURL}, true},
+		{"BadSchemeURL", registry.EntityMetadata{Versioned: v1, URL: "http://hello.world/bar/goo"}, false},
+		{"BadQueryURL", registry.EntityMetadata{Versioned: v1, URL: "https://hello.world/bar?goo=1"}, false},
+		{"BadFragmentURL", registry.EntityMetadata{Versioned: v1, URL: "https://hello.world/bar#goo"}, false},
+		{"BadPortURL", registry.EntityMetadata{Versioned: v1, URL: "https://hello.world:123/bar"}, false},
+		{"BadURL1", registry.EntityMetadata{Versioned: v1, URL: "hello.world"}, false},
+		{"BadURL2", registry.EntityMetadata{Versioned: v1, URL: "127.0.0.1:1234"}, false},
+		{"ValidEmail", registry.EntityMetadata{Versioned: v1, Email: EntityValidEmail}, true},
+		{"BadEmail1", registry.EntityMetadata{Versioned: v1, Email: "hello world.org"}, false},
+		{"BadEmail2", registry.EntityMetadata{Versioned: v1, Email: "Hello World <hello@world.org>"}, false},
+		{"BadEmail3", registry.EntityMetadata{Versioned: v1, Email: "@world.org"}, false},
+		{"BadEmail4", registry.EntityMetadata{Versioned: v1, Email: "hello@.org"}, false},
+		{"ValidKeybase", registry.EntityMetadata{Versioned: v1, Keybase: EntityValidKeybase}, true},
+		{"BadKeybase1", registry.EntityMetadata{Versioned: v1, Keybase: "helloworld-"}, false},
+		{"BadKeybase2", registry.EntityMetadata{Versioned: v1, Keybase: "https://keybase.io/hello"}, false},
+		{"BadKeybase3", registry.EntityMetadata{Versioned: v1, Keybase: "foo-bar"}, false},
+		{"BadKeybase4", registry.EntityMetadata{Versioned: v1, Keybase: "foo:bar"}, false},
+		{"ValidTwitter", registry.EntityMetadata{Versioned: v1, Twitter: EntityValidTwitter}, true},
+		{"BadTwitter1", registry.EntityMetadata{Versioned: v1, Twitter: "helloworld-"}, false},
+		{"BadTwitter2", registry.EntityMetadata{Versioned: v1, Twitter: "https://twitter.com/hello"}, false},
+		{"BadTwitter3", registry.EntityMetadata{Versioned: v1, Twitter: "foo-bar"}, false},
+		{"BadTwitter4", registry.EntityMetadata{Versioned: v1, Twitter: "foo:bar"}, false},
 	}
 )
 
@@ -95,7 +99,7 @@ func validBounds(version uint16, name, url, email, keybase, twitter string) bool
 	return true
 }
 
-func init() {
+func init() { //nolint:gochecknoinits
 	// Generate test cases for entity metadata by permutating through all field
 	// value lists below.
 	versions := []uint16{0, 1, 2}

--- a/testcases/testcases.go
+++ b/testcases/testcases.go
@@ -81,6 +81,20 @@ var (
 	}
 )
 
+// validBounds returns true iff all the given entity metadata fields are within
+// each field's valid bounds.
+func validBounds(version uint16, name, url, email, keybase, twitter string) bool {
+	if version < registry.MinSupportedVersion || version > registry.MaxSupportedVersion ||
+		len(name) > registry.MaxEntityNameLength ||
+		len(url) > registry.MaxEntityURLLength ||
+		len(email) > registry.MaxEntityEmailLength ||
+		len(keybase) > registry.MaxEntityKeybaseLength ||
+		len(twitter) > registry.MaxEntityTwitterLength {
+		return false
+	}
+	return true
+}
+
 func init() {
 	// Generate test cases for entity metadata by permutating through all field
 	// value lists below.
@@ -110,19 +124,10 @@ func init() {
 									Keybase:   keybase,
 									Twitter:   twitter,
 								}
-								valid := true
-								if v < registry.MinSupportedVersion || v > registry.MaxSupportedVersion ||
-									len(name) > registry.MaxEntityNameLength ||
-									len(url) > registry.MaxEntityURLLength ||
-									len(email) > registry.MaxEntityEmailLength ||
-									len(keybase) > registry.MaxEntityKeybaseLength ||
-									len(twitter) > registry.MaxEntityTwitterLength {
-									valid = false
-								}
 								tc := EntityMetadataTestCase{
 									Name:       "ExtendedVersionAndSizeChecks: " + strconv.Itoa(count),
 									EntityMeta: meta,
-									Valid:      valid,
+									Valid:      validBounds(v, name, url, email, keybase, twitter),
 								}
 								EntityMetadataExtendedVersionAndSize = append(
 									EntityMetadataExtendedVersionAndSize, tc,


### PR DESCRIPTION
Smaller Go code refactors to allow using a more default golangci-lint configuration.